### PR TITLE
Catch error when calling updateGoPathGoRootFromConfig

### DIFF
--- a/src-vscode-mock/activate.ts
+++ b/src-vscode-mock/activate.ts
@@ -118,6 +118,11 @@ export async function activate(lspClient: LspClient, lspServer: LspServer, logge
 	return updateGoPathGoRootFromConfig().then(() => {
 		lspClient.sendTelemetryEvent(workspace.getConfiguration('go'));
 		offerToInstallTools();
+	}).catch((e) => {
+		lspClient.showMessage({
+			type: MessageType.Error,
+			message: e.stack,
+		});
 	});
 }
 

--- a/src/goInstallTools.ts
+++ b/src/goInstallTools.ts
@@ -290,6 +290,11 @@ export function updateGoPathGoRootFromConfig(): Promise<void> {
 
 	// If GOPATH is still not set, then use the one from `go env`
 	let goRuntimePath = getGoRuntimePath();
+
+	if (!goRuntimePath) {
+		return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately'));
+	}
+
 	return new Promise<void>((resolve, reject) => {
 		cp.execFile(goRuntimePath, ['env', 'GOPATH'], (err, stdout, stderr) => {
 			if (err) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -559,7 +559,18 @@ export interface ICheckResult {
  */
 export function runTool(args: string[], cwd: string, severity: string, useStdErr: boolean, toolName: string, env: any, printUnexpectedOutput: boolean, token?: vscode.CancellationToken): Promise<ICheckResult[]> {
 	let goRuntimePath = getGoRuntimePath();
-	let cmd = toolName ? getBinPath(toolName) : goRuntimePath;
+	let cmd;
+
+	if (toolName) {
+		cmd = getBinPath(toolName);
+	} else {
+		if (!goRuntimePath) {
+			return Promise.reject(new Error('Cannot find "go" binary. Update PATH or GOROOT appropriately'));
+		}
+
+		cmd = goRuntimePath;
+	}
+
 	let p: cp.ChildProcess;
 	if (token) {
 		token.onCancellationRequested(() => {


### PR DESCRIPTION
If the go binary is not available from the PATH, the server outputs this
error message.

server --> client: b'{"jsonrpc":"2.0","method":"window/logMessage","params":{"type":1,"message":"[lspserver] (node:17641) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 3): TypeError: \\"file\\" argument must be a non-empty string"}}'
server --> client: b'{"jsonrpc":"2.0","method":"window/logMessage","params":{"type":1,"message":"[lspserver] (node:17641) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code."}}'

The TypeError comes from node's child_process.execFile when the
vscode-go code tries to run the go binary, because goRuntimePath's value
is undefined.

This patch makes updateGoPathGoRootFromConfig return a rejected promise
with a meaningful error message when the go binary is not found, and
then makes the server send an error message to the client including the
error and backtrace.  The result looks like this:

server --> client: b'{"jsonrpc":"2.0","method":"window/showMessage","params":{"type":1,"message":"Error: Cannot find \\"go\\" binary. Update PATH or GOROOT appropriately\\n    at Object.updateGoPathGoRootFromConfig (/home/emaisin/src/go-language-server/out/src/goInstallTools.js:280:31)\\n    at Object.<anonymous> (/home/emaisin/src/go-language-server/out/src-vscode-mock/activate.js:105:33)\\n    at Generator.next (<anonymous>)\\n    at /home/emaisin/src/go-language-server/out/src-vscode-mock/activate.js:13:71\\n    at new Promise (<anonymous>)\\n    at __awaiter (/home/emaisin/src/go-language-server/out/src-vscode-mock/activate.js:9:12)\\n    at Object.activate (/home/emaisin/src/go-language-server/out/src-vscode-mock/activate.js:34:12)\\n    at LspServer.<anonymous> (/home/emaisin/src/go-language-server/out/src-vscode-mock/lsp-server.js:93:31)\\n    at Generator.next (<anonymous>)\\n    at /home/emaisin/src/go-language-server/out/src-vscode-mock/lsp-server.js:13:71"}}'

It's not very readable as-is, but I suppose that when the client
prints it in a log, the \n will be presented as real line breaks.  But
the important thing is that the info is there, so that one has a lead to
start debugging.

There was another instance (in runTool) where the result of
getGoRuntimePath was not checked, so it generated a similar unclear
error.

Fixes #16

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>