### PR TITLE
Bump vscode-languageclient to 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,8 @@
     "pkginfo": "^0.4.1",
     "vscode-debugprotocol": "^1.11.0",
     "vscode-extension-telemetry": "0.0.10",
-    "vscode-languageclient": "^2.5.0",
     "vscode-languageserver": "^3.5.0",
+    "vscode-languageserver-protocol": "^3.5.0",
     "vscode-uri": "^1.0.1"
   },
   "devDependencies": {

--- a/src-vscode-mock/vscode.ts
+++ b/src-vscode-mock/vscode.ts
@@ -23,6 +23,6 @@ export * from './window';
 export * from './workspace';
 
 export { Uri }
-export { MessageType } from 'vscode-languageclient/lib/protocol';
+export { MessageType } from 'vscode-languageserver-protocol';
 export { DiagnosticSeverity, CompletionItemKind, SymbolKind } from 'vscode-languageserver-types';
 export { Disposable, Event, Emitter as EventEmitter, CancellationToken, CancellationTokenSource } from 'vscode-languageserver'


### PR DESCRIPTION
Use the latest released version of vscode-languageclient.  The protocol
bits have been moved to a new package, vscode-languageserver-protocol,
so add a dependency on it and adjust the code.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>