### PR TITLE
Send LSP-compliant responses to definition requests

### DIFF
--- a/src-vscode-mock/lsp-server.ts
+++ b/src-vscode-mock/lsp-server.ts
@@ -179,9 +179,13 @@ export class LspServer {
 		await this.activation;
 		return this.executeOnDocument('definition', params, async document => {
 			const definition = await this.definitionProvider.provideDefinition(document, params.position, lsp.CancellationToken.None);
-			if (definition)
-				return definition;
-			else
+			if (definition) {
+				const result: lsp.Definition = {
+					uri: definition.uri,
+					range: definition.range,
+				};
+				return result;
+			} else
 				return [];
 		});
 	}


### PR DESCRIPTION
The responses to textDocument/definition requests contain some fields
that are not specified in the LSP.  Unlike for the codelens requests,
they do not represent a huge amount of data, but still we should not
include them.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>