### PR TITLE
Send LSP-compliant structures for commands in codeLens/resolve responses

### DIFF
--- a/src-vscode-mock/lsp-server.ts
+++ b/src-vscode-mock/lsp-server.ts
@@ -13,7 +13,7 @@ import { LspClient } from './lsp-client';
 import { SnippetProposalProvider } from './snippet-proposal-provider';
 import { TextDocument } from './text-document';
 import { TextEditor } from './text-editor';
-import { Location, CodeLens, Range } from './types';
+import { Location, CodeLens, Range, Command } from './types';
 import { uriToPath, uriToStringUri } from './utils';
 import { window } from './window';
 import { workspace, WorkspaceFolder } from './workspace';
@@ -42,6 +42,14 @@ export interface IServerOptions {
 }
 
 export const WORKSPACE_EDIT_COMMAND = 'workspace-edit';
+
+function vscodeCommandToLspCommand(vscodeCommand: Command): lsp.Command {
+	return {
+		title: vscodeCommand.title,
+		command: vscodeCommand.command,
+		arguments: vscodeCommand.arguments,
+	};
+}
 
 export class LspServer {
 
@@ -281,7 +289,7 @@ export class LspServer {
 			const resolvedCodeLens: CodeLens = await this.referenceCodeLensProvider.resolveCodeLens(codeLens, lsp.CancellationToken.None);
 			const result: lsp.CodeLens = {
 				range: resolvedCodeLens.range,
-				command: resolvedCodeLens.command,
+				command: vscodeCommandToLspCommand(resolvedCodeLens.command),
 				data: resolvedCodeLens.data,
 			};
 


### PR DESCRIPTION
When a Command LSP record is output in a codeLens/resolve response, it
contains these fields, which are not specified by the LSP:

  "uriRangeOrPosition": {
      "start": {
          "character": 10,
          "line": 32
      },
      "end": {
          "character": 18,
          "line": 32
      }
  },
  "rangeOrUri": {
      "scheme": "file",
      "fsPath": "/home/emaisin/src/ls-interact/go-test/test.go",
      "external": "file:///home/emaisin/src/ls-interact/go-test/test.go",
      "path": "/home/emaisin/src/ls-interact/go-test/test.go",
      "$mid": 1
  }

This patch makes the server output only the fields that are specified by
the LSP.  I made a standalone function to convert from a vscode Command
to an LSP Command, because we might have to re-use it in other responses
that contain commands.

Signed-off-by: Simon Marchi <simon.marchi@ericsson.com>