### PR TITLE
fixed lint on goSuggest

### DIFF
--- a/src/goSuggest.ts
+++ b/src/goSuggest.ts
@@ -200,7 +200,7 @@ export class GoCompletionItemProvider implements vscode.CompletionItemProvider {
 								let snippet = prefix + ' ${1:methodName}(${2}) ${3} \{\n\t$0\n\}';
 								// [TypeFox]
 								// auxItem.insertText = new vscode.SnippetString(snippet);
-								auxItem.insertText =snippet;
+								auxItem.insertText = snippet;
 								auxItem.insertTextFormat = vscode.InsertTextFormat.Snippet;
 								suggestions.push(auxItem);
 							}


### PR DESCRIPTION
src/goSuggest.ts[203, 29]: missing whitespace

return error by `> node ./node_modules/tslint/bin/tslint ./src/*.ts ./src/debugAdapter/*.ts ./src-vscode-mock/*.ts ./test/*.ts`